### PR TITLE
Introduced `JsonResult` and related classes

### DIFF
--- a/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonBody.cs
+++ b/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonBody.cs
@@ -1,0 +1,56 @@
+﻿using System.Net;
+using Newtonsoft.Json;
+
+namespace Skybrud.Essentials.AspNetCore.Models.Json {
+
+    /// <summary>
+    /// Class representing the body of a JSON response.
+    /// </summary>
+    public class JsonBody {
+
+        /// <summary>
+        /// Gets or sets the meta data for the response.
+        /// </summary>
+        [JsonProperty(PropertyName = "meta")]
+        public JsonMetaData Meta { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the data object.
+        /// </summary>
+        [JsonProperty(PropertyName = "data", NullValueHandling = NullValueHandling.Ignore)]
+        public object Data { get; set; }
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance with default options.
+        /// </summary>
+        public JsonBody() { }
+
+        /// <summary>
+        /// Initializes a new instance based on the specified <paramref name="status"/> and <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="status">The HTTP status.</param>
+        /// <param name="error">The error message.</param>
+        public JsonBody(HttpStatusCode status, string error) {
+            Meta.Code = status;
+            Meta.Error = error;
+        }
+
+        /// <summary>
+        /// Initializes a new instance based on the specified <paramref name="status"/>, <paramref name="error"/> message and <paramref name="data"/>.
+        /// </summary>
+        /// <param name="status">The HTTP status.</param>
+        /// <param name="error">The error message.</param>
+        /// <param name="data">The data.</param>
+        public JsonBody(HttpStatusCode status, string error, object data) {
+            Meta.Code = status;
+            Meta.Error = error;
+            Data = data;
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonMetaData.cs
+++ b/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonMetaData.cs
@@ -1,0 +1,25 @@
+﻿using System.Net;
+using Newtonsoft.Json;
+
+namespace Skybrud.Essentials.AspNetCore.Models.Json {
+
+    /// <summary>
+    /// Class representing the meta data of a JSON response.
+    /// </summary>
+    public class JsonMetaData {
+
+        /// <summary>
+        /// Gets or sets the status code.
+        /// </summary>
+        [JsonProperty(PropertyName = "code")]
+        public HttpStatusCode Code { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error message. If the error message is <c>NULL</c>, the property will not be a part of the JSON response.
+        /// </summary>
+        [JsonProperty(PropertyName = "error", NullValueHandling = NullValueHandling.Ignore)]
+        public string Error { get; set; }
+
+    }
+
+}

--- a/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonNetResult.cs
+++ b/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonNetResult.cs
@@ -7,7 +7,7 @@ namespace Skybrud.Essentials.AspNetCore.Models.Json {
     /// <summary>
     /// Class representing a JOSN based result serialized using <strong>Newtonsoft.Json</strong>.
     /// </summary>
-    public class JsonResult : ContentResult {
+    public class JsonNetResult : ContentResult {
 
         #region Constructors
 
@@ -15,14 +15,14 @@ namespace Skybrud.Essentials.AspNetCore.Models.Json {
         /// Initializes a new <strong>200 OK</strong> result wrapping the specified <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
-        public JsonResult(object value) : this(HttpStatusCode.OK, value) { }
+        public JsonNetResult(object value) : this(HttpStatusCode.OK, value) { }
 
         /// <summary>
         /// Initializes a new result with <paramref name="status"/> wrapping the specified <paramref name="value"/>.
         /// </summary>
         /// <param name="status">The HTTP status code.</param>
         /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
-        public JsonResult(HttpStatusCode status, object value) {
+        public JsonNetResult(HttpStatusCode status, object value) {
 
             // Serialize the data to a JSON string using JSON.net
             string json = JsonConvert.SerializeObject(value, Formatting.None);
@@ -41,68 +41,68 @@ namespace Skybrud.Essentials.AspNetCore.Models.Json {
         /// Returns a new <strong>200 OK</strong> result with the specified <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult Ok(object value) {
-            return new JsonResult(HttpStatusCode.OK, value);
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult Ok(object value) {
+            return new JsonNetResult(HttpStatusCode.OK, value);
         }
 
         /// <summary>
         /// Returns a new <strong>201 Created</strong> result with the specified <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult Created(object value) {
-            return new JsonResult(HttpStatusCode.Created, value);
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult Created(object value) {
+            return new JsonNetResult(HttpStatusCode.Created, value);
         }
 
         /// <summary>
         /// Returns a new <strong>400 Bad Request</strong> result with the specified <paramref name="error"/> message.
         /// </summary>
         /// <param name="error">A message describing the error.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult BadRequest(string error) {
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult BadRequest(string error) {
             JsonBody body = new(HttpStatusCode.BadRequest, error, null);
-            return new JsonResult(HttpStatusCode.BadRequest, body);
+            return new JsonNetResult(HttpStatusCode.BadRequest, body);
         }
 
         /// <summary>
         /// Returns a new <strong>401 Unauthorized</strong> result with the specified <paramref name="error"/> message.
         /// </summary>
         /// <param name="error">A message describing the error.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult Unauthorized(string error) {
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult Unauthorized(string error) {
             JsonBody body = new(HttpStatusCode.Unauthorized, error, null);
-            return new JsonResult(HttpStatusCode.Unauthorized, body);
+            return new JsonNetResult(HttpStatusCode.Unauthorized, body);
         }
 
         /// <summary>
         /// Returns a new <strong>403 Forbidden</strong> result with the specified <paramref name="error"/> message.
         /// </summary>
         /// <param name="error">A message describing the error.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult Forbidden(string error) {
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult Forbidden(string error) {
             JsonBody body = new(HttpStatusCode.Forbidden, error, null);
-            return new JsonResult(HttpStatusCode.Forbidden, body);
+            return new JsonNetResult(HttpStatusCode.Forbidden, body);
         }
 
         /// <summary>
         /// Returns a new <strong>404 Not Found</strong> result with the specified <paramref name="error"/> message.
         /// </summary>
         /// <param name="error">A message describing the error.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult NotFound(string error) {
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult NotFound(string error) {
             JsonBody body = new(HttpStatusCode.NotFound, error, null);
-            return new JsonResult(HttpStatusCode.NotFound, body);
+            return new JsonNetResult(HttpStatusCode.NotFound, body);
         }
 
         /// <summary>
         /// Returns a new <strong>500 Internal Server Error</strong> result with the specified <paramref name="error"/> message.
         /// </summary>
         /// <param name="error">A message describing the error.</param>
-        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
-        public static JsonResult InternalError(string error) {
+        /// <returns>An instance of <see cref="JsonNetResult"/>.</returns>
+        public static JsonNetResult InternalError(string error) {
             JsonBody body = new(HttpStatusCode.InternalServerError, error, null);
-            return new JsonResult(HttpStatusCode.InternalServerError, body);
+            return new JsonNetResult(HttpStatusCode.InternalServerError, body);
         }
 
         #endregion

--- a/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonResult.cs
+++ b/src/Skybrud.Essentials.AspNetCore/Models/Json/JsonResult.cs
@@ -1,0 +1,112 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace Skybrud.Essentials.AspNetCore.Models.Json {
+
+    /// <summary>
+    /// Class representing a JOSN based result serialized using <strong>Newtonsoft.Json</strong>.
+    /// </summary>
+    public class JsonResult : ContentResult {
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new <strong>200 OK</strong> result wrapping the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
+        public JsonResult(object value) : this(HttpStatusCode.OK, value) { }
+
+        /// <summary>
+        /// Initializes a new result with <paramref name="status"/> wrapping the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="status">The HTTP status code.</param>
+        /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
+        public JsonResult(HttpStatusCode status, object value) {
+
+            // Serialize the data to a JSON string using JSON.net
+            string json = JsonConvert.SerializeObject(value, Formatting.None);
+
+            StatusCode = (int) status;
+            ContentType = "application/json";
+            Content = json;
+
+        }
+
+        #endregion
+
+        #region Static methods
+
+        /// <summary>
+        /// Returns a new <strong>200 OK</strong> result with the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult Ok(object value) {
+            return new JsonResult(HttpStatusCode.OK, value);
+        }
+
+        /// <summary>
+        /// Returns a new <strong>201 Created</strong> result with the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value/body of the result. The value will be serialized to JSON before being returned to the client.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult Created(object value) {
+            return new JsonResult(HttpStatusCode.Created, value);
+        }
+
+        /// <summary>
+        /// Returns a new <strong>400 Bad Request</strong> result with the specified <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="error">A message describing the error.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult BadRequest(string error) {
+            JsonBody body = new(HttpStatusCode.BadRequest, error, null);
+            return new JsonResult(HttpStatusCode.BadRequest, body);
+        }
+
+        /// <summary>
+        /// Returns a new <strong>401 Unauthorized</strong> result with the specified <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="error">A message describing the error.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult Unauthorized(string error) {
+            JsonBody body = new(HttpStatusCode.Unauthorized, error, null);
+            return new JsonResult(HttpStatusCode.Unauthorized, body);
+        }
+
+        /// <summary>
+        /// Returns a new <strong>403 Forbidden</strong> result with the specified <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="error">A message describing the error.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult Forbidden(string error) {
+            JsonBody body = new(HttpStatusCode.Forbidden, error, null);
+            return new JsonResult(HttpStatusCode.Forbidden, body);
+        }
+
+        /// <summary>
+        /// Returns a new <strong>404 Not Found</strong> result with the specified <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="error">A message describing the error.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult NotFound(string error) {
+            JsonBody body = new(HttpStatusCode.NotFound, error, null);
+            return new JsonResult(HttpStatusCode.NotFound, body);
+        }
+
+        /// <summary>
+        /// Returns a new <strong>500 Internal Server Error</strong> result with the specified <paramref name="error"/> message.
+        /// </summary>
+        /// <param name="error">A message describing the error.</param>
+        /// <returns>An instance of <see cref="JsonResult"/>.</returns>
+        public static JsonResult InternalError(string error) {
+            JsonBody body = new(HttpStatusCode.InternalServerError, error, null);
+            return new JsonResult(HttpStatusCode.InternalServerError, body);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Skybrud.Essentials.AspNetCore/Skybrud.Essentials.AspNetCore.csproj
+++ b/src/Skybrud.Essentials.AspNetCore/Skybrud.Essentials.AspNetCore.csproj
@@ -27,7 +27,7 @@
 
   <!-- Include NuGet dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.0" />
     <PackageReference Include="Skybrud.Essentials" Version="1.1.38" />
   </ItemGroup>


### PR DESCRIPTION
This PR introduces the `JsonNetResult` class and as well as the `JsonBody` and `JsonMetaData` classes.

By default, when returning a value from an API controller, the value is serialized using `System.Text.Json`. Sometimes it might however be more ideal to use `Newtonsoft.Json` instead, which is what the `JsonNetResult` class is for.

The `JsonBody` and `JsonMetaData` classes help adding a bit more logic - eg. to return error responses like we used to do with our  [Skybrud.WebApi.Json](https://github.com/abjerner/Skybrud.WebApi.Json) package.

Usage is something like:

### 200 OK

```csharp
return JsonNetResult.Ok(new { hello = "world" });
```

returns:

```json
{
    "hello": "world"
}
```

### 201 Created

```csharp
return JsonNetResult.Created(new { hello = "world" });
```

returns:

```json
{
    "hello": "world"
}
```

### 400 Bad Request

```csharp
return JsonNetResult.BadRequest("Nope");
```

returns:

```json
{
    "meta": {
        "code": 400,
        "error": "Nope"
    }
}
```

### 401 Unauthorized

```csharp
return JsonNetResult.Unauthorized("Not authorized");
```

returns:

```json
{
    "meta": {
        "code": 401,
        "error": "Not authorized"
    }
}
```

### 403 Forbidden

```csharp
return JsonNetResult.Forbidden("Forbidden");
```

returns:

```json
{
    "meta": {
        "code": 403,
        "error": "Forbidden"
    }
}
```

### 404 Not Found

```csharp
return JsonNetResult.NotFound("Not Found");
```

returns:

```json
{
    "meta": {
        "code": 404,
        "error": "Not Found"
    }
}
```

### 500 Internal Server Error

```csharp
return JsonNetResult.InternalError("Computer says no...");
```

returns:

```json
{
    "meta": {
        "code": 500,
        "error": "Computer says no..."
    }
}
```